### PR TITLE
chime: fix clang variables for the kernel

### DIFF
--- a/BoardConfig-chime.mk
+++ b/BoardConfig-chime.mk
@@ -56,8 +56,8 @@ TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_SOURCE := kernel/xiaomi/chime
 TARGET_KERNEL_CONFIG := vendor/chime_defconfig
 TARGET_KERNEL_CLANG_COMPILE := true
-TARGET_KERNEL_CLANG_PATH := $(shell pwd)/prebuilts/clang/host/linux-x86/clang-snapdragon
-TARGET_KERNEL_CLANG_VERSION := sdllvm
+#TARGET_KERNEL_CLANG_PATH := $(shell pwd)/prebuilts/clang/host/linux-x86/clang-snapdragon
+TARGET_KERNEL_CLANG_VERSION := snapdragon
 TARGET_KERNEL_ADDITIONAL_FLAGS := LD=ld.lld AR=llvm-ar NM=llvm-nm OBJCOPY=llvm-objcopy OBJDUMP=llvm-objdump STRIP=llvm-strip
 TARGET_KERNEL_ADDITIONAL_FLAGS += HOSTCFLAGS="-fuse-ld=lld -Wno-unused-command-line-argument"
 BOARD_MKBOOTIMG_ARGS += --header_version $(BOARD_BOOTIMG_HEADER_VERSION)


### PR DESCRIPTION
Our vendorsetup.sh makes it so that clang is downloaded as "clang-snapdragon", however, our BoardConfig.mk specifies that the version is "sdllvm".

Because of TARGET_KERNEL_CLANG_VERSION being used as a variable to determine which specific clang we want to use in prebuilts/clang/host/linux-x86

Example: 
TARGET_KERNEL_CLANG_VERSION := snapdragon
KERNEL_CLANG_VERSION := clang-$(TARGET_KERNEL_CLANG_VERSION)

This means that the version it would look for is the one that's called "clang-snapdragon", anything after the dash may change depending on what "TARGET_KERNEL_CLANG_VERSION" specifies.

Now that our clang version is properly setup, we don't need to use the variable "TARGET_KERNEL_CLANG_PATH", since the build system already knows what to look for.